### PR TITLE
Accessibility fixes

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -10,7 +10,7 @@ const Header = () => {
           tarjoajia on hyvin paljon. Ideana on tuottaa nyt hankalasti ja pirstoutuneena oleva tieto
           yhteen paikkaan kaikkien toimijoiden avoimesti saataville.
         </Typography>
-        <Divider sx={{ borderColor: 'common.black' }} />
+        <Divider sx={{ borderColor: 'common.black' }} aria-hidden="true" />
         <Grid container justifyContent="space-around" sx={{ p: '10px' }}>
           <Grid item>
             <Link href="https://european-union.europa.eu/index_fi" color="inherit">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ import { Container, Divider, Grid, Link, Paper, Typography } from '@mui/material
 
 const Header = () => {
   return (
-    <Paper sx={{ color: 'common.black', bgcolor: '#F1F8FF' }}>
+    <Paper component="footer" sx={{ color: 'common.black', bgcolor: '#F1F8FF' }}>
       <Container>
         <Typography align="center" sx={{ p: '20px' }}>
           Business Finlandin mukaan sertifiointi on laadun tae kansainvälisessä kaupassa.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,7 +47,7 @@ const Home = ({ firstCompanies, initialResultsAmount }: HomeProps) => {
       />
       {loading && offset === 0 ? (
         <Grid container item alignItems="center" justifyContent="center" sx={{ marginY: '10vh' }}>
-          <CircularProgress />
+          <CircularProgress aria-label="Ladataan" />
         </Grid>
       ) : (
         <>
@@ -82,7 +82,7 @@ const Home = ({ firstCompanies, initialResultsAmount }: HomeProps) => {
                     Hae lisää
                   </Button>
                 ) : (
-                  <CircularProgress />
+                  <CircularProgress aria-label="Ladataan" />
                 )}
               </Grid>
             )}


### PR DESCRIPTION
- Changes footer to use the html footer element
- Hides non meaningful divider from screen readers
- Adds aria-label to loading icons to express its meaning to screen reader users

There was one issue with the Autocomplete component (used with city and certificate selection) where selecting an option when using Android Talkback wasn't possible. The issue comes from MUI component library and was [reported there](https://github.com/mui/material-ui/issues/31081). The issue doesn't totally block Android Talkback users from using the application since typing in the field still works.

No other findings were gathered from the accessibility testing