### PR TITLE
Add more info text to alert

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,6 +28,10 @@ const Home = () => {
         >
           Tässä palvelussa voit hakea matkailualan yritysten suorittamia sertifikaatteja joko
           yrityksen nimen, y-tunnuksen, kaupungin tai sertifikaatin perusteella.
+          <br />
+          <br />
+          Sertifikaattilukija on kokeiluversio, jonka takia kaikki sertifioidut tai STF-merkin
+          saaneet yritykset eivät vielä löydy lukijan hakuehdoilla.
         </Alert>
       )}
       <SearchForm


### PR DESCRIPTION
Added "Sertifikaattilukija on kokeiluversio, jonka takia kaikki sertifioidut tai STF-merkin saaneet yritykset eivät vielä löydy lukijan hakuehdoilla." to home page alert box with a couple of line breaks.